### PR TITLE
chore: optimize CI — path filters, concurrency, skip release builds on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
-    branches: [master]
+    branches: [master, main]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/**'
+      - 'Makefile'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -100,9 +111,10 @@ jobs:
           echo "- Setpoints: **${SETPOINTS}**" >> "$GITHUB_STEP_SUMMARY"
           echo "- Governance files: ✅" >> "$GITHUB_STEP_SUMMARY"
 
-  # Gate 5: Build verification
+  # Gate 5: Build verification (skip on PRs — release.yml handles tagged builds)
   build:
     name: Build (${{ matrix.target }})
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -131,6 +143,7 @@ jobs:
 
   docker:
     name: Docker Build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["v*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

- **Concurrency groups** added to both `ci.yml` and `release.yml` — superseded runs on the same branch are auto-cancelled, eliminating wasted minutes on rapid pushes
- **Path filters** on `ci.yml` `pull_request` trigger — PRs that only touch docs, markdown, or non-Rust files skip CI entirely
- **Release builds gated** with `if: github.event_name != 'pull_request'` — the 3-platform build matrix (linux-amd64, macos-amd64, macos-arm64) and Docker build no longer run on PRs
- **`workflow_dispatch`** added to `ci.yml` for manual trigger capability

### Cost impact

| Metric | Before | After |
|--------|--------|-------|
| PR jobs | 7 (check, test, pr-lint, control-audit, build x3, docker) | 4 (check, test, pr-lint, control-audit + auto-merge) |
| Estimated PR CI time | ~20 min | ~5 min |
| Redundant runs on rapid push | All run to completion | Auto-cancelled |

### Files changed

- `.github/workflows/ci.yml` — concurrency, path filters, workflow_dispatch, build/docker gating
- `.github/workflows/release.yml` — concurrency group

## Test plan

- [ ] Open a PR touching only `.md` files — CI should not trigger
- [ ] Open a PR touching `.rs` files — check, test, pr-lint, control-audit run; build matrix and docker do NOT run
- [ ] Push to `master` — all jobs including build matrix and docker run
- [ ] Push a tag `v*` — release.yml runs with concurrency group
- [ ] Rapidly push two commits to a PR branch — first run gets cancelled

Generated with [Claude Code](https://claude.com/claude-code)